### PR TITLE
Implement peer judging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,4 +2,7 @@ module.exports = {
   extends: [
     '@codeday/typescript',
   ],
+  rules: {
+    'linebreak-style': 0,
+  },
 };

--- a/prisma/migrations/migrate.lock
+++ b/prisma/migrations/migrate.lock
@@ -3,3 +3,4 @@
 20220725145454-add-images-tags
 20220824150625-add-photos-featured
 20221123064810-add-media-featured
+20230308210621-add-peer-judging

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,8 +75,10 @@ model Project {
   metadata       Metadata[]
   metrics        Metric[]
   judgements     Judgement[]
+  peerJudgements PeerJudgement[]
   reactionCounts ReactionCount[]
   tags           Tag[]
+  kudos          Kudos[]
 }
 
 model Media {
@@ -231,4 +233,28 @@ model Photo {
   eventId      String
   regionId     String?
   eventGroupId String?
+}
+
+model PeerJudgement {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  username  String
+  eventId   String
+  project   Project @relation(fields: [projectId], references: [id])
+  projectId String
+
+  @@unique([username, eventId, projectId])
+}
+
+model Kudos {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  username  String
+  reviewed  Boolean @default(false)
+  project   Project @relation(fields: [projectId], references: [id])
+  projectId String
 }

--- a/src/auth/AuthContext.ts
+++ b/src/auth/AuthContext.ts
@@ -45,16 +45,16 @@ export class AuthContext {
   }
 
   async isEventParticipant(eventId: string): Promise<boolean> {
-    const userProjects = await Container.get(PrismaClient).project.findMany({
+    return await Container.get(PrismaClient).project.count({
       where: {
+        eventId,
         members: {
           some: {
             username: this.username,
           },
         },
       },
-    });
-    return userProjects.map((p) => p.eventId).includes(eventId);
+    }) > 0;
   }
 
   async isProjectAdminById(id: string): Promise<boolean> {

--- a/src/auth/AuthContext.ts
+++ b/src/auth/AuthContext.ts
@@ -44,6 +44,19 @@ export class AuthContext {
     return project.members?.map((m) => m.username).includes(this.username) || false;
   }
 
+  async isEventParticipant(eventId: string): Promise<boolean> {
+    const userProjects = await Container.get(PrismaClient).project.findMany({
+      where: {
+        members: {
+          some: {
+            username: this.username,
+          },
+        },
+      },
+    });
+    return userProjects.map((p) => p.eventId).includes(eventId);
+  }
+
   async isProjectAdminById(id: string): Promise<boolean> {
     const project = await Container.get(PrismaClient).project.findFirst({ where: { id }, include: { members: true } });
     if (!project) return false;

--- a/src/resolvers/PeerJudgementMutation.ts
+++ b/src/resolvers/PeerJudgementMutation.ts
@@ -15,15 +15,22 @@ export class PeerJudgementMutation {
     async peerJudgeProjects(
         @Ctx() { auth }: Context,
         @Arg('eventId') eventId: string,
-        @Arg('projects') projects: string[],
+        @Arg('projects', () => [String]) projects: string[],
     ): Promise<boolean> {
       if (!auth.username) throw new Error('Auth token does not include username');
       if (!auth.isEventParticipant(eventId)) throw new Error('You are not a member of any projects at this event!');
       if (await Container.get(PrismaClient).peerJudgement.findFirst({ where: { eventId, username: auth.username } })) {
-        throw new Error('You have already voted');
+        // throw new Error('You have already voted');
+        // This way people can submit new votes really easily. Probably a better way to handle this but this is simple
+        await Container.get(PrismaClient).peerJudgement.deleteMany({ where: { eventId, username: auth.username } });
       }
-      const dbProjects = await Container.get(PrismaClient).project.findMany({ where: { id: { in: projects } } });
+      const dbProjects = await Container.get(PrismaClient).project.findMany(
+        { where: { id: { in: projects } }, select: { eventId: true, members: true, id: true } },
+      );
       if (!dbProjects.every((p) => p.eventId === eventId)) throw new Error('eventId mismatch');
+      if (dbProjects.some((p) => p.members.some((m) => m.username === auth.username))) {
+        throw new Error('You cannot vote for your own project!');
+      }
       // CreateMany does not exist in this version of prisma
       dbProjects.forEach(async (project) => {
         await Container.get(PrismaClient).peerJudgement.create({

--- a/src/resolvers/PeerJudgementMutation.ts
+++ b/src/resolvers/PeerJudgementMutation.ts
@@ -1,0 +1,43 @@
+import {
+  Arg, Ctx, Mutation, Resolver,
+} from 'type-graphql';
+import { Container, Inject } from 'typedi';
+import { PrismaClient } from '@prisma/client';
+import { PeerJudgement } from '../types/PeerJudgement';
+import { Context } from '../context';
+
+@Resolver(PeerJudgement)
+export class PeerJudgementMutation {
+    @Inject(() => PrismaClient)
+    private readonly prisma : PrismaClient;
+
+    @Mutation(() => Boolean)
+    async peerJudgeProjects(
+        @Ctx() { auth }: Context,
+        @Arg('eventId') eventId: string,
+        @Arg('projects') projects: string[],
+    ): Promise<boolean> {
+      if (!auth.username) throw new Error('Auth token does not include username');
+      if (!auth.isEventParticipant(eventId)) throw new Error('You are not a member of any projects at this event!');
+      if (await Container.get(PrismaClient).peerJudgement.findFirst({ where: { eventId, username: auth.username } })) {
+        throw new Error('You have already voted');
+      }
+      const dbProjects = await Container.get(PrismaClient).project.findMany({ where: { id: { in: projects } } });
+      if (!dbProjects.every((p) => p.eventId === eventId)) throw new Error('eventId mismatch');
+      // CreateMany does not exist in this version of prisma
+      dbProjects.forEach(async (project) => {
+        await Container.get(PrismaClient).peerJudgement.create({
+          data: {
+            project: {
+              connect: {
+                id: project.id,
+              },
+            },
+            eventId: project.eventId,
+            username: auth.username as string,
+          },
+        });
+      });
+      return true;
+    }
+}

--- a/src/types/Kudos.ts
+++ b/src/types/Kudos.ts
@@ -1,0 +1,23 @@
+import { Field, ObjectType } from 'type-graphql';
+import { Project } from './Project';
+
+@ObjectType()
+export class Kudos {
+    @Field(() => String)
+    id: string;
+
+    @Field(() => Date)
+    createdAt: Date;
+
+    @Field(() => Date)
+    updatedAt: Date;
+
+    @Field(() => String)
+    username: string;
+
+    @Field(() => Boolean)
+    reviewed: boolean;
+
+    @Field(() => Project)
+    project: Project;
+}

--- a/src/types/Project.ts
+++ b/src/types/Project.ts
@@ -13,6 +13,8 @@ import { MediaType } from './MediaType';
 import { MediaTopic } from './MediaTopic';
 import { ReactionCount } from './ReactionCount';
 import { Context } from '../context';
+import { Kudos } from './Kudos';
+import { PeerJudgement } from './PeerJudgement';
 
 @ObjectType()
 export class Project {
@@ -141,12 +143,11 @@ export class Project {
   ): Promise<string[]> {
     const tags = await Container.get(PrismaClient).tag.findMany({
       where: {
-        projects: { some: { id: this.id }}
+        projects: { some: { id: this.id } },
       },
     });
     return tags.map((t) => t.id);
   }
-
 
   @Field(() => [Metadata], { nullable: true })
   async metadata(
@@ -187,5 +188,17 @@ export class Project {
     @Ctx() { auth }: Context,
   ): Promise<boolean> {
     return auth.isEventAdmin(this.eventId);
+  }
+
+  @Field(() => [PeerJudgement], { nullable: true })
+  async peerJudgements(
+      @Ctx() { auth }: Context,
+  ): Promise<PeerJudgement[]> {
+    if (!auth.isEventAdmin(this.eventId)) throw new Error('You are not an event admin');
+    return <Promise<PeerJudgement[]>><unknown>Container.get(PrismaClient).peerJudgement.findMany({
+      where: {
+        projectId: this.id,
+      },
+    });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,6 +3383,11 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.0.tgz#b943f129275c41d435eb54b643bbffee71dccf57"
   integrity sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA==
 
+undici@2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-2.0.7.tgz#3804cffa4c64bc6ae71e6b0f4d85054ea6b0fb91"
+  integrity sha512-3YoSJEva11i4iW+nUfo+r5EP+piSO667SU57hfNeW3kPG5ACl7IgHzhT+bT23j0v1lgs+vIHfxQfTGK32HEPIQ==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"


### PR DESCRIPTION
This pull request implements Peer Judging, a new judging format to be tested at CodeDay events.

In this PR: 
* New `PeerJudgement` and `Kudos` database models (Kudos currently unimplemented)
* A new `peerJudgeProjects` mutation, for event participants to submit their votes
* Query implementation for event admins to view judging results

Things from my end I want sanity-checked before merge: 
* Everything with the auth ok?
* Everything with the typing ok? 
* Do RMs count as `isEventAdmin`? I was able to view results locally however I'm unsure if this is because I am a global admin